### PR TITLE
allow seting the container policy

### DIFF
--- a/bin/ssbench-master
+++ b/bin/ssbench-master
@@ -132,7 +132,7 @@ def run_scenario(args):
         if args.op_count != DEFAULT_FROM_SCENARIO else None
     run_seconds = int(args.run_seconds) \
         if args.run_seconds != DEFAULT_FROM_SCENARIO else None
-    policy = str(args.policy) \
+    policy = args.policy \
         if args.policy != DEFAULT_FROM_SCENARIO else None
 
     delete_after = args.delete_after

--- a/bin/ssbench-master
+++ b/bin/ssbench-master
@@ -132,6 +132,8 @@ def run_scenario(args):
         if args.op_count != DEFAULT_FROM_SCENARIO else None
     run_seconds = int(args.run_seconds) \
         if args.run_seconds != DEFAULT_FROM_SCENARIO else None
+    policy = str(args.policy) \
+        if args.policy != DEFAULT_FROM_SCENARIO else None
 
     delete_after = args.delete_after
 
@@ -150,6 +152,7 @@ def run_scenario(args):
                               operation_count=operation_count,
                               run_seconds=run_seconds,
                               delete_after=delete_after,
+                              policy=policy,
                               **scenario_kwargs)
 
     # Sanity-check batch_size
@@ -539,6 +542,10 @@ if __name__ == "__main__":
              'scenario file may specify a delete_after value, but this flag '
              'will override it.  So if you specify 0 here, a non-zero '
              'delete_after value in the scenario file will be suppressed.')
+    run_scenario_arg_parser.add_argument(
+        '-p', '--policy', default=DEFAULT_FROM_SCENARIO,
+        metavar='POLICY',
+        help='Set the storage policy on the containers created.')
     run_scenario_arg_parser.set_defaults(func=run_scenario)
 
     report_scenario_arg_parser = subparsers.add_parser(

--- a/scenarios/ec_test_scenarios/ec_huge_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 5
   },
-  "operation_count": 5,
+  "run_seconds": 1200,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-huge-mixed",

--- a/scenarios/ec_test_scenarios/ec_huge_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test.scenario
@@ -6,7 +6,7 @@
     "size_max": 5368709120
   }],
   "initial_files": {
-    "objects": 5,
+    "objects": 5
   },
   "operation_count": 5,
   "crud_profile": [10, 75, 15, 0],

--- a/scenarios/ec_test_scenarios/ec_huge_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-huge-mixed",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_huge_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test.scenario
@@ -6,9 +6,9 @@
     "size_max": 5368709120
   }],
   "initial_files": {
-    "objects": 0,
+    "objects": 5,
   },
-  "operation_count": 500,
+  "operation_count": 5,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-huge-mixed",

--- a/scenarios/ec_test_scenarios/ec_huge_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 1073741824,
+    "size_max": 5368709120
+  }],
+  "initial_files": {
+    "objects": 0,
+  },
+  "operation_count": 500,
+  "crud_profile": [10, 75, 15, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_huge_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test_read_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 5368709120
   }],
   "initial_files": {
-    "objects": 5,
+    "objects": 5
   },
   "operation_count": 5,
   "crud_profile": [0, 100, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_huge_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test_read_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 5
   },
-  "operation_count": 5,
+  "run_seconds": 1200,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-huge-readonly",

--- a/scenarios/ec_test_scenarios/ec_huge_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test_read_only.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-huge-readonly",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_huge_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test_read_only.scenario
@@ -6,9 +6,9 @@
     "size_max": 5368709120
   }],
   "initial_files": {
-    "objects": 0,
+    "objects": 5,
   },
-  "operation_count": 500,
+  "operation_count": 5,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-huge-readonly",

--- a/scenarios/ec_test_scenarios/ec_huge_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test_read_only.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 1073741824,
+    "size_max": 5368709120
+  }],
+  "initial_files": {
+    "objects": 0,
+  },
+  "operation_count": 500,
+  "crud_profile": [0, 100, 0, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_huge_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test_write_only.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 1073741824,
+    "size_max": 5368709120
+  }],
+  "initial_files": {
+    "objects": 0,
+  },
+  "operation_count": 500,
+  "crud_profile": [100, 0, 0, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_huge_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test_write_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 5368709120
   }],
   "initial_files": {
-    "objects": 5,
+    "objects": 5
   },
   "operation_count": 15,
   "crud_profile": [100, 0, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_huge_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test_write_only.scenario
@@ -6,9 +6,9 @@
     "size_max": 5368709120
   }],
   "initial_files": {
-    "objects": 0,
+    "objects": 5,
   },
-  "operation_count": 500,
+  "operation_count": 15,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-huge-writeonly",

--- a/scenarios/ec_test_scenarios/ec_huge_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test_write_only.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-huge-writeonly",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_huge_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_huge_test_write_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 5
   },
-  "operation_count": 15,
+  "run_seconds": 1200,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-huge-writeonly",

--- a/scenarios/ec_test_scenarios/ec_large_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-large-mixed",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_large_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 15
   },
-  "operation_count": 100,
+  "run_seconds": 1200,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-large-mixed",

--- a/scenarios/ec_test_scenarios/ec_large_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 104857600,
+    "size_max": 262144000
+  }],
+  "initial_files": {
+    "objects": 0,
+  },
+  "operation_count": 500,
+  "crud_profile": [10, 75, 15, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_large_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test.scenario
@@ -6,7 +6,7 @@
     "size_max": 262144000
   }],
   "initial_files": {
-    "objects": 15,
+    "objects": 15
   },
   "operation_count": 100,
   "crud_profile": [10, 75, 15, 0],

--- a/scenarios/ec_test_scenarios/ec_large_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test.scenario
@@ -6,9 +6,9 @@
     "size_max": 262144000
   }],
   "initial_files": {
-    "objects": 0,
+    "objects": 15,
   },
-  "operation_count": 500,
+  "operation_count": 100,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-large-mixed",

--- a/scenarios/ec_test_scenarios/ec_large_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test_read_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 262144000
   }],
   "initial_files": {
-    "objects": 15,
+    "objects": 15
   },
   "operation_count": 100,
   "crud_profile": [0, 100, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_large_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test_read_only.scenario
@@ -6,9 +6,9 @@
     "size_max": 262144000
   }],
   "initial_files": {
-    "objects": 0,
+    "objects": 15,
   },
-  "operation_count": 500,
+  "operation_count": 100,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-large-readonly",

--- a/scenarios/ec_test_scenarios/ec_large_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test_read_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 15
   },
-  "operation_count": 100,
+  "run_seconds": 1200,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-large-readonly",

--- a/scenarios/ec_test_scenarios/ec_large_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test_read_only.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 104857600,
+    "size_max": 262144000
+  }],
+  "initial_files": {
+    "objects": 0,
+  },
+  "operation_count": 500,
+  "crud_profile": [0, 100, 0, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_large_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test_read_only.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-large-readonly",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_large_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test_write_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 15
   },
-  "operation_count": 100,
+  "run_seconds": 1200,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-large-writeonly",

--- a/scenarios/ec_test_scenarios/ec_large_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test_write_only.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-large-writeonly",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_large_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test_write_only.scenario
@@ -6,9 +6,9 @@
     "size_max": 262144000
   }],
   "initial_files": {
-    "objects": 0,
+    "objects": 15,
   },
-  "operation_count": 500,
+  "operation_count": 100,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-large-writeonly",

--- a/scenarios/ec_test_scenarios/ec_large_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test_write_only.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 104857600,
+    "size_max": 262144000
+  }],
+  "initial_files": {
+    "objects": 0,
+  },
+  "operation_count": 500,
+  "crud_profile": [100, 0, 0, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_large_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_large_test_write_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 262144000
   }],
   "initial_files": {
-    "objects": 15,
+    "objects": 15
   },
   "operation_count": 100,
   "crud_profile": [100, 0, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_medium_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test.scenario
@@ -6,7 +6,7 @@
     "size_max": 26214400
   }],
   "initial_files": {
-    "objects": 100,
+    "objects": 100
   },
   "operation_count": 500,
   "crud_profile": [10, 75, 15, 0],

--- a/scenarios/ec_test_scenarios/ec_medium_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-medium-mixed",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_medium_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 100
   },
-  "operation_count": 500,
+  "run_seconds": 1200,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-medium-mixed",

--- a/scenarios/ec_test_scenarios/ec_medium_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 5242880,
+    "size_max": 26214400
+  }],
+  "initial_files": {
+    "objects": 10,
+  },
+  "operation_count": 500,
+  "crud_profile": [10, 75, 15, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_medium_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test.scenario
@@ -6,7 +6,7 @@
     "size_max": 26214400
   }],
   "initial_files": {
-    "objects": 10,
+    "objects": 100,
   },
   "operation_count": 500,
   "crud_profile": [10, 75, 15, 0],

--- a/scenarios/ec_test_scenarios/ec_medium_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test_read_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 26214400
   }],
   "initial_files": {
-    "objects": 100,
+    "objects": 100
   },
   "operation_count": 500,
   "crud_profile": [0, 100, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_medium_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test_read_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 100
   },
-  "operation_count": 500,
+  "run_seconds": 1200,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-medium-readonly",

--- a/scenarios/ec_test_scenarios/ec_medium_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test_read_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 26214400
   }],
   "initial_files": {
-    "objects": 10,
+    "objects": 100,
   },
   "operation_count": 500,
   "crud_profile": [0, 100, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_medium_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test_read_only.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 5242880,
+    "size_max": 26214400
+  }],
+  "initial_files": {
+    "objects": 10,
+  },
+  "operation_count": 500,
+  "crud_profile": [0, 100, 0, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_medium_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test_read_only.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-medium-readonly",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_medium_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test_write_only.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 5242880,
+    "size_max": 26214400
+  }],
+  "initial_files": {
+    "objects": 10,
+  },
+  "operation_count": 500,
+  "crud_profile": [100, 0, 0, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_medium_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test_write_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 26214400
   }],
   "initial_files": {
-    "objects": 100,
+    "objects": 100
   },
   "operation_count": 500,
   "crud_profile": [100, 0, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_medium_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test_write_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 26214400
   }],
   "initial_files": {
-    "objects": 10,
+    "objects": 100,
   },
   "operation_count": 500,
   "crud_profile": [100, 0, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_medium_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test_write_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 100
   },
-  "operation_count": 500,
+  "run_seconds": 1200,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-medium-writeonly",

--- a/scenarios/ec_test_scenarios/ec_medium_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_medium_test_write_only.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-medium-writeonly",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_miniscule_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 1000
   },
-  "operation_count": 5000,
+  "run_seconds": 1200,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-miniscule-mixed",

--- a/scenarios/ec_test_scenarios/ec_miniscule_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 10,
+    "size_max": 2048
+  }],
+  "initial_files": {
+    "objects": 0,
+  },
+  "operation_count": 500,
+  "crud_profile": [10, 75, 15, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_miniscule_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test.scenario
@@ -6,7 +6,7 @@
     "size_max": 2048
   }],
   "initial_files": {
-    "objects": 1000,
+    "objects": 1000
   },
   "operation_count": 5000,
   "crud_profile": [10, 75, 15, 0],

--- a/scenarios/ec_test_scenarios/ec_miniscule_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-miniscule-mixed",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_miniscule_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test.scenario
@@ -6,9 +6,9 @@
     "size_max": 2048
   }],
   "initial_files": {
-    "objects": 0,
+    "objects": 1000,
   },
-  "operation_count": 500,
+  "operation_count": 5000,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-miniscule-mixed",

--- a/scenarios/ec_test_scenarios/ec_miniscule_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test_read_only.scenario
@@ -6,9 +6,9 @@
     "size_max": 2048
   }],
   "initial_files": {
-    "objects": 0,
+    "objects": 1000,
   },
-  "operation_count": 500,
+  "operation_count": 5000,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-miniscule-readonly",

--- a/scenarios/ec_test_scenarios/ec_miniscule_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test_read_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 2048
   }],
   "initial_files": {
-    "objects": 1000,
+    "objects": 1000
   },
   "operation_count": 5000,
   "crud_profile": [0, 100, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_miniscule_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test_read_only.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-miniscule-readonly",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_miniscule_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test_read_only.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 10,
+    "size_max": 2048
+  }],
+  "initial_files": {
+    "objects": 0,
+  },
+  "operation_count": 500,
+  "crud_profile": [0, 100, 0, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_miniscule_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test_read_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 1000
   },
-  "operation_count": 5000,
+  "run_seconds": 1200,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-miniscule-readonly",

--- a/scenarios/ec_test_scenarios/ec_miniscule_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test_write_only.scenario
@@ -6,9 +6,9 @@
     "size_max": 2048
   }],
   "initial_files": {
-    "objects": 0,
+    "objects": 1000,
   },
-  "operation_count": 500,
+  "operation_count": 5000,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-miniscule-writeonly",

--- a/scenarios/ec_test_scenarios/ec_miniscule_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test_write_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 1000
   },
-  "operation_count": 5000,
+  "run_seconds": 1200,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-miniscule-writeonly",

--- a/scenarios/ec_test_scenarios/ec_miniscule_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test_write_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 2048
   }],
   "initial_files": {
-    "objects": 1000,
+    "objects": 1000
   },
   "operation_count": 5000,
   "crud_profile": [100, 0, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_miniscule_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test_write_only.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 10,
+    "size_max": 2048
+  }],
+  "initial_files": {
+    "objects": 0,
+  },
+  "operation_count": 500,
+  "crud_profile": [100, 0, 0, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_miniscule_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_miniscule_test_write_only.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-miniscule-writeonly",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_small_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 1048576,
+    "size_max": 5242880
+  }],
+  "initial_files": {
+    "objects": 100,
+  },
+  "operation_count": 500,
+  "crud_profile": [10, 75, 15, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_small_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test.scenario
@@ -6,7 +6,7 @@
     "size_max": 5242880
   }],
   "initial_files": {
-    "objects": 1000,
+    "objects": 1000
   },
   "operation_count": 1500,
   "crud_profile": [10, 75, 15, 0],

--- a/scenarios/ec_test_scenarios/ec_small_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 1000
   },
-  "operation_count": 1500,
+  "run_seconds": 1200,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-small-mixed",

--- a/scenarios/ec_test_scenarios/ec_small_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-small-mixed",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_small_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test.scenario
@@ -6,9 +6,9 @@
     "size_max": 5242880
   }],
   "initial_files": {
-    "objects": 100,
+    "objects": 1000,
   },
-  "operation_count": 500,
+  "operation_count": 1500,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-small-mixed",

--- a/scenarios/ec_test_scenarios/ec_small_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test_read_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 5242880
   }],
   "initial_files": {
-    "objects": 1000,
+    "objects": 1000
   },
   "operation_count": 1500,
   "crud_profile": [0, 100, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_small_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test_read_only.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 1048576,
+    "size_max": 5242880
+  }],
+  "initial_files": {
+    "objects": 100,
+  },
+  "operation_count": 500,
+  "crud_profile": [0, 100, 0, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_small_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test_read_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 1000
   },
-  "operation_count": 1500,
+  "run_seconds": 1200,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-small-readonly",

--- a/scenarios/ec_test_scenarios/ec_small_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test_read_only.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-small-readonly",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_small_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test_read_only.scenario
@@ -6,9 +6,9 @@
     "size_max": 5242880
   }],
   "initial_files": {
-    "objects": 100,
+    "objects": 1000,
   },
-  "operation_count": 500,
+  "operation_count": 1500,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-small-readonly",

--- a/scenarios/ec_test_scenarios/ec_small_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test_write_only.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 1048576,
+    "size_max": 5242880
+  }],
+  "initial_files": {
+    "objects": 100,
+  },
+  "operation_count": 500,
+  "crud_profile": [100, 0, 0, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_small_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test_write_only.scenario
@@ -6,9 +6,9 @@
     "size_max": 5242880
   }],
   "initial_files": {
-    "objects": 100,
+    "objects": 1000,
   },
-  "operation_count": 500,
+  "operation_count": 1500,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-small-writeonly",

--- a/scenarios/ec_test_scenarios/ec_small_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test_write_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 5242880
   }],
   "initial_files": {
-    "objects": 1000,
+    "objects": 1000
   },
   "operation_count": 1500,
   "crud_profile": [100, 0, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_small_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test_write_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 1000
   },
-  "operation_count": 1500,
+  "run_seconds": 1200,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-small-writeonly",

--- a/scenarios/ec_test_scenarios/ec_small_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_small_test_write_only.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-small-writeonly",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_tiny_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 1000
   },
-  "operation_count": 2000,
+  "run_seconds": 1200,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-tiny-mixed",

--- a/scenarios/ec_test_scenarios/ec_tiny_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 409600,
+    "size_max": 819200
+  }],
+  "initial_files": {
+    "objects": 0,
+  },
+  "operation_count": 500,
+  "crud_profile": [10, 75, 15, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_tiny_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-tiny-mixed",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_tiny_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test.scenario
@@ -6,9 +6,9 @@
     "size_max": 819200
   }],
   "initial_files": {
-    "objects": 0,
+    "objects": 1000,
   },
-  "operation_count": 500,
+  "operation_count": 2000,
   "crud_profile": [10, 75, 15, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-tiny-mixed",

--- a/scenarios/ec_test_scenarios/ec_tiny_test.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test.scenario
@@ -6,7 +6,7 @@
     "size_max": 819200
   }],
   "initial_files": {
-    "objects": 1000,
+    "objects": 1000
   },
   "operation_count": 2000,
   "crud_profile": [10, 75, 15, 0],

--- a/scenarios/ec_test_scenarios/ec_tiny_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test_read_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 819200
   }],
   "initial_files": {
-    "objects": 0,
+    "objects": 1000
   },
   "operation_count": 2000,
   "crud_profile": [0, 100, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_tiny_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test_read_only.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 409600,
+    "size_max": 819200
+  }],
+  "initial_files": {
+    "objects": 0,
+  },
+  "operation_count": 500,
+  "crud_profile": [0, 100, 0, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_tiny_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test_read_only.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-tiny-readonly",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/scenarios/ec_test_scenarios/ec_tiny_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test_read_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 1000
   },
-  "operation_count": 2000,
+  "run_seconds": 1200,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-tiny-readonly",

--- a/scenarios/ec_test_scenarios/ec_tiny_test_read_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test_read_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 0,
   },
-  "operation_count": 500,
+  "operation_count": 2000,
   "crud_profile": [0, 100, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-tiny-readonly",

--- a/scenarios/ec_test_scenarios/ec_tiny_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test_write_only.scenario
@@ -1,0 +1,17 @@
+{
+  "name": "EC validation test scenario",
+  "sizes": [{
+    "name": "objects",
+    "size_min": 409600,
+    "size_max": 819200
+  }],
+  "initial_files": {
+    "objects": 0,
+  },
+  "operation_count": 500,
+  "crud_profile": [100, 0, 0, 0],
+  "user_count": 4,
+  "container_base": "ssbench",
+  "container_count": 100,
+  "container_concurrency": 10
+}

--- a/scenarios/ec_test_scenarios/ec_tiny_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test_write_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 1000
   },
-  "operation_count": 2000,
+  "run_seconds": 1200,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-tiny-writeonly",

--- a/scenarios/ec_test_scenarios/ec_tiny_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test_write_only.scenario
@@ -6,7 +6,7 @@
     "size_max": 819200
   }],
   "initial_files": {
-    "objects": 0,
+    "objects": 1000
   },
   "operation_count": 2000,
   "crud_profile": [100, 0, 0, 0],

--- a/scenarios/ec_test_scenarios/ec_tiny_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test_write_only.scenario
@@ -8,7 +8,7 @@
   "initial_files": {
     "objects": 0,
   },
-  "operation_count": 500,
+  "operation_count": 2000,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
   "container_base": "ssbench-ectest-tiny-writeonly",

--- a/scenarios/ec_test_scenarios/ec_tiny_test_write_only.scenario
+++ b/scenarios/ec_test_scenarios/ec_tiny_test_write_only.scenario
@@ -11,7 +11,7 @@
   "operation_count": 500,
   "crud_profile": [100, 0, 0, 0],
   "user_count": 4,
-  "container_base": "ssbench",
+  "container_base": "ssbench-ectest-tiny-writeonly",
   "container_count": 100,
   "container_concurrency": 10
 }

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         'bin/ssbench-master',
         'bin/ssbench-worker',
     ],
-    data_files=[('share/ssbench/scenarios', glob('scenarios/*')),
+    data_files=[('share/ssbench/scenarios', glob('scenarios/*.scenario')),
+                ('share/ssbench/scenarios/ec_test_scenarios', glob('scenarios/ec_test_scenarios/*.scenario')),
                 ('share/ssbench', ['CHANGELOG', 'AUTHORS', 'LICENSE'])],
 )

--- a/ssbench/master.py
+++ b/ssbench/master.py
@@ -37,10 +37,7 @@ from ssbench.util import raise_file_descriptor_limit
 
 
 def _container_creator(storage_urls, token, container, policy=None):
-    put_headers = None
-    if policy is not None:
-        put_headers = {}
-        put_headers['x-storage-policy'] = policy
+    put_headers = None if policy is None else {'x-storage-policy': policy}
     storage_url = random.choice(storage_urls)
     http_conn = client.http_connection(storage_url)
     try:

--- a/ssbench/master.py
+++ b/ssbench/master.py
@@ -36,7 +36,11 @@ from ssbench.run_state import RunState
 from ssbench.util import raise_file_descriptor_limit
 
 
-def _container_creator(storage_urls, token, container):
+def _container_creator(storage_urls, token, container, policy=None):
+    put_headers = None
+    if policy is not None:
+        put_headers = {}
+        put_headers['x-storage-policy'] = policy
     storage_url = random.choice(storage_urls)
     http_conn = client.http_connection(storage_url)
     try:
@@ -44,7 +48,7 @@ def _container_creator(storage_urls, token, container):
                               http_conn=http_conn)
     except client.ClientException:
         client.put_container(storage_url, token, container,
-                             http_conn=http_conn)
+                             headers=put_headers, http_conn=http_conn)
 
 
 def _container_deleter(concurrency, storage_urls, token, container_info):
@@ -328,7 +332,7 @@ class Master(object):
             pool = gevent.pool.Pool(scenario.container_concurrency)
             for container in scenario.containers:
                 pool.spawn(_container_creator, storage_urls, c_token,
-                           container)
+                           container, policy=scenario.policy)
             pool.join()
 
         # Enqueue initialization jobs

--- a/ssbench/scenario.py
+++ b/ssbench/scenario.py
@@ -34,7 +34,7 @@ class Scenario(object):
     def __init__(self, scenario_filename=None, container_count=None,
                  user_count=None, operation_count=None, run_seconds=None,
                  block_size=None, _scenario_data=None,
-                 version=ssbench.version, delete_after=None):
+                 version=ssbench.version, delete_after=None, policy=None):
         """Initializes the object from a scenario file on disk.
 
         :scenario_filename: path to a scenario file
@@ -85,6 +85,14 @@ class Scenario(object):
             raise ValueError('A scenario requires run_seconds or '
                              'operation_count')
 
+        # storage policy to use for containers
+        if policy is not None:
+            self.policy = str(policy)
+        else:
+            self.policy = self._scenario_data.get('policy', None)
+            if self.policy is not None:
+                self.policy = str(self.policy)
+
         self.block_size = block_size
         self.name = self._scenario_data['name']
         self.container_base = self._scenario_data.get('container_base',
@@ -94,7 +102,8 @@ class Scenario(object):
         else:
             self.container_count = self._scenario_data.get(
                 'container_count', 100)
-        self.containers = ['%s_%06d' % (self.container_base, i)
+        policy_name = 'default_policy' if self.policy is None else self.policy
+        self.containers = ['%s_%06d_%s' % (self.container_base, i, policy_name)
                            for i in xrange(self.container_count)]
         self.container_concurrency = self._scenario_data.get(
             'container_concurrency', 10)

--- a/ssbench/tests/test_scenario.py
+++ b/ssbench/tests/test_scenario.py
@@ -198,9 +198,18 @@ class TestScenario(ScenarioFixture):
             Scenario(self.stub_scenario_file, user_count=0)
 
     def test_containers_default(self):
-        assert_list_equal(self.scenario.containers,
-                          ['ssbench_%06d' % i for i in xrange(100)])
+        assert_list_equal(
+            self.scenario.containers,
+            ['ssbench_%06d_default_policy' % i for i in xrange(100)])
         assert_equal(10, self.scenario.container_concurrency)
+
+    def test_containers_custom_policy(self):
+        self.scenario_dict['policy'] = 'candlestick'
+        self.write_scenario_file()
+        scenario = Scenario(self.stub_scenario_file)
+        assert_list_equal(
+            scenario.containers,
+            ['ssbench_%06d_candlestick' % i for i in xrange(100)])
 
     def test_containers_custom(self):
         self.scenario_dict['container_base'] = 'iggy'
@@ -208,8 +217,9 @@ class TestScenario(ScenarioFixture):
         self.scenario_dict['container_concurrency'] = 13
         self.write_scenario_file()
         scenario = Scenario(self.stub_scenario_file)
-        assert_list_equal(scenario.containers,
-                          ['iggy_%06d' % i for i in xrange(77)])
+        assert_list_equal(
+            scenario.containers,
+            ['iggy_%06d_default_policy' % i for i in xrange(77)])
         assert_equal(13, scenario.container_concurrency)
 
     def test_crud_pcts(self):


### PR DESCRIPTION
Set it with -p/--policy on the CLI or set it by using "policy" in
the scenario file.

The containers created by ssbench will now have the policy name
appended to them. If no policy name is given (resulting in the
cluster default being used), the policy suffix is "default_policy".