### PR TITLE
Explicitly set the pep8 version.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,5 @@ mock>=1.0.1
 flexmock>=0.9.6
 nose>=1.3.0
 coverage>=3.6
-flake8>=2.1.0
+flake8==2.1.0
+pep8==1.4.6


### PR DESCRIPTION
Setting the version of pep8 in test-requirements.txt helps folks using
virtualenv to run the style check on the code more easily.