### PR TITLE
Add IPv6 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -501,6 +501,15 @@ columns have the object sizes in them, which are defined in the scenario file.
 You can think of the two CVS lines as a linear denormalization of the contents
 of the two-dimensional table output.
 
+IPv6 support
+------------
+`ssbench` supports IPv6 for both the Swift communication, as well as between the
+master and the workers. When using a hostname, `ssbench` will attempt to
+guess whether to use IPv6 or not. If the host resolves to both IPv4 and IPv6,
+`ssbench` picks IPv4. If this is not the desired behavior, please specify the IP
+address explicitly. To bind to all interfaces, use the `::` address for IPv6;
+for localhost, use `::1`.
+
 
 How Does It Scale?
 ==================
@@ -532,7 +541,6 @@ per second with ``--noop`` (see below) with this command-line (a
 But with a ``--batch-size`` of 8, I can get around **19,500** requests per second::
 
   $ ssbench-master run-scenario ... -u 24 -o 30000 --workers 3 --noop --batch-size 8
-
 
 HTTPS on OS X
 -------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cython
 gevent
 geventhttpclient>=1.0a
-pyzmq>=14.0.1
+pyzmq==14.0.1
 msgpack-python>=0.3.0
 Mako

--- a/ssbench/master.py
+++ b/ssbench/master.py
@@ -34,6 +34,7 @@ from ssbench.importer import random
 import ssbench.swift_client as client
 from ssbench.run_state import RunState
 from ssbench.util import raise_file_descriptor_limit
+from ssbench.util import is_ipv6
 
 
 def _container_creator(storage_urls, token, container, policy=None):
@@ -84,10 +85,13 @@ class Master(object):
         if zmq_bind_ip is not None and zmq_work_port is not None:
             work_endpoint = 'tcp://%s:%d' % (zmq_bind_ip, zmq_work_port)
             results_endpoint = 'tcp://%s:%d' % (zmq_bind_ip, zmq_results_port)
+            ipv6 = is_ipv6(zmq_bind_ip)
             self.context = zmq.Context()
             self.work_push = self.context.socket(zmq.PUSH)
+            self.work_push.ipv6 = ipv6
             self.work_push.bind(work_endpoint)
             self.results_pull = self.context.socket(zmq.PULL)
+            self.results_pull.ipv6 = ipv6
             self.results_pull.bind(results_endpoint)
         self.connect_timeout = connect_timeout
         self.network_timeout = network_timeout

--- a/ssbench/tests/test_master.py
+++ b/ssbench/tests/test_master.py
@@ -19,6 +19,7 @@ import tempfile
 import StringIO
 from unittest import TestCase
 from flexmock import flexmock
+import mock
 import zmq.green as zmq
 
 import msgpack
@@ -84,10 +85,13 @@ class TestMaster(ScenarioFixture, TestCase):
             self.results_endpoint,
         ).once
 
-        self.master = Master(self.zmq_host, self.zmq_work_port,
-                             self.zmq_results_port,
-                             connect_timeout=3.14159,
-                             network_timeout=2.71828)
+        with mock.patch.object(ssbench.master, 'is_ipv6') as mock_is_ipv6:
+            mock_is_ipv6.return_value = False
+            self.master = Master(self.zmq_host, self.zmq_work_port,
+                                 self.zmq_results_port,
+                                 connect_timeout=3.14159,
+                                 network_timeout=2.71828)
+            mock_is_ipv6.assert_called_once_with(self.zmq_host)
 
         self._send_calls = []
         self._recv_returns = []

--- a/ssbench/tests/test_util.py
+++ b/ssbench/tests/test_util.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2016 SwiftStack, Inc.
 
-import ssbench.util
 import math
+import mock
+import ssbench.util
 from unittest import TestCase
 
 
@@ -36,3 +37,24 @@ class TestUtil(TestCase):
 
         for seq, std in sequences:
             self.assertEqual(ssbench.util.uncorrected_stdev(seq), std)
+
+    def test_is_ipv6(self):
+        addrs = [('127.0.0.1', False),
+                 ('::1', True),
+                 ('0.0.0.0', False),
+                 ('::', True)]
+        for addr, ipv6 in addrs:
+            self.assertEqual(ssbench.util.is_ipv6(addr), ipv6)
+
+    @mock.patch.object(ssbench.util.socket, 'getaddrinfo')
+    def test_is_ipv6_tuples(self, mock_getaddrinfo):
+        test_tuples = [[(2, 1, 6, '', ('10.0.0.1', 0)),
+                        (10, 1, 6, '', ('dead::beef', 0, 0, 0))],
+                       [(10, 1, 6, '', ('dead::beef', 0, 0, 0))],
+                       [(2, 1, 6, '', ('10.0.0.100', 0))],
+                       [(10, 1, 6, '', ('dead::beef', 0, 0, 0)),
+                        (2, 1, 6, '', ('10.0.0.1', 0))]]
+        expected_values = [False, True, False, False]
+        mock_getaddrinfo.side_effect = test_tuples
+        for expected in expected_values:
+            self.assertEqual(ssbench.util.is_ipv6('host'), expected)

--- a/ssbench/tests/test_worker.py
+++ b/ssbench/tests/test_worker.py
@@ -16,6 +16,7 @@
 import time
 import socket
 from flexmock import flexmock
+import mock
 from nose.tools import assert_equal, assert_raises, assert_true
 import gevent.queue
 import zmq.green as zmq
@@ -65,9 +66,12 @@ class TestWorker(object):
             gevent.queue.Queue,
         ).once
 
-        self.worker = worker.Worker(self.zmq_host, self.zmq_work_port,
-                                    self.zmq_results_port, self.worker_id,
-                                    self.max_retries)
+        with mock.patch.object(ssbench.worker, 'is_ipv6') as mock_is_ipv6:
+            mock_is_ipv6.return_value = False
+            self.worker = worker.Worker(self.zmq_host, self.zmq_work_port,
+                                        self.zmq_results_port, self.worker_id,
+                                        self.max_retries)
+            mock_is_ipv6.assert_called_once_with(self.zmq_host)
         self.mock_worker = flexmock(self.worker)
 
         self.stub_time = 98438243.3921

--- a/ssbench/util.py
+++ b/ssbench/util.py
@@ -3,6 +3,7 @@
 import math
 import os
 import resource
+import socket
 
 
 def add_dicts(*args, **kwargs):
@@ -32,6 +33,17 @@ def raise_file_descriptor_limit():
         except ValueError:
             nofile_target /= 1024
         break
+
+
+def is_ipv6(addr):
+    """
+    For hostnames, we will use IPv4, if both IPv4 and IPv6 are present as
+    results of getaddrinfo().
+    """
+    sockaddrs = socket.getaddrinfo(addr, None)
+    if any([addr_tuple[0] == socket.AF_INET for addr_tuple in sockaddrs]):
+        return False
+    return True
 
 
 def mean(iterable):

--- a/ssbench/worker.py
+++ b/ssbench/worker.py
@@ -39,6 +39,7 @@ from geventhttpclient.response import HTTPConnectionClosed
 
 from ssbench.importer import random
 from ssbench.util import add_dicts, raise_file_descriptor_limit
+from ssbench.util import is_ipv6
 import ssbench.swift_client as client
 
 
@@ -88,6 +89,7 @@ class Worker(object):
                  max_retries, profile_count=0, concurrency=256, batch_size=1):
         work_endpoint = 'tcp://%s:%d' % (zmq_host, zmq_work_port)
         results_endpoint = 'tcp://%s:%d' % (zmq_host, zmq_results_port)
+        ipv6 = is_ipv6(zmq_host)
         self.worker_id = worker_id
         self.max_retries = max_retries
         self.profile_count = profile_count
@@ -103,8 +105,10 @@ class Worker(object):
 
         self.context = zmq.Context()
         self.work_pull = self.context.socket(zmq.PULL)
+        self.work_pull.ipv6 = ipv6
         self.work_pull.connect(work_endpoint)
         self.results_push = self.context.socket(zmq.PUSH)
+        self.results_push.ipv6 = ipv6
         self.results_push.connect(results_endpoint)
 
         self.result_queue = gevent.queue.Queue()


### PR DESCRIPTION
For IPv6, zmq requires an ipv6 flag to be set on the socket. The patch
    adds the detection of IPv6 addresses. Master and worker then use this
    function to set the flag as appropriate.