### PR TITLE
Add 'get_headers' scenario option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,8 @@ defining a benchmark run.  Specifically, it defines:
   run will be created with this Storage Policy.
   This can be overridden for any given run with the ``--policy storage-policy``
   flag to ``ssbench-master run-scenario``.
+- A ``put_headers`` which lists extra headers to include in object GET/read
+  requests. In the form of a dictionary of (header, value) pairs.
 
 For each operation of the benchmark run, a size category is first chosen based
 on the relative counts for each size category in the ``initial_files``

--- a/ssbench/scenario.py
+++ b/ssbench/scenario.py
@@ -139,6 +139,12 @@ class Scenario(object):
         else:
             self.delete_after = self._scenario_data.get('delete_after')
 
+        # Object GET headers
+        # TODO You might want different GET headers for different sizes, so
+        #      maybe add a get_headers to each size and defaults to the
+        #      global, just like the CRUD_profile.
+        self.get_headers = self._scenario_data.get('get_headers')
+
     def packb(self):
         return msgpack.packb({
             '_scenario_data': self._scenario_data,
@@ -219,7 +225,8 @@ class Scenario(object):
             return self.create_job(size_str, i)
         elif crud_index == 1:
             return self.job(size_str, type=ssbench.READ_OBJECT,
-                            block_size=self.block_size)
+                            block_size=self.block_size,
+                            get_headers=self.get_headers)
         elif crud_index == 2:
             return self.job(
                 size_str, type=ssbench.UPDATE_OBJECT,

--- a/ssbench/swift_client.py
+++ b/ssbench/swift_client.py
@@ -666,7 +666,7 @@ def delete_container(url, token, container, http_conn=None):
 
 
 def get_object(url, token, container, name, http_conn=None,
-               resp_chunk_size=65536):
+               resp_chunk_size=65536, extra_headers=None):
     """
     Modified for benchmarking to GET an object in "chunk sizes" of
     resp_chunk_size, throwing away the actual contents.
@@ -688,6 +688,8 @@ def get_object(url, token, container, name, http_conn=None,
     path = '%s/%s/%s' % (parsed.path, quote(container), quote(name))
     method = 'GET'
     headers = {'X-Auth-Token': token}
+    if extra_headers:
+        headers.update(extra_headers)
     start = time()
     conn.request(method, path, '', headers)
     resp = conn.getresponse()

--- a/ssbench/worker.py
+++ b/ssbench/worker.py
@@ -305,6 +305,8 @@ class Worker(object):
                                   client.DEFAULT_CONNECT_TIMEOUT),
                     call_info.get('network_timeout',
                                   client.DEFAULT_NETWORK_TIMEOUT))
+            if extra_keys.get('extra_headers'):
+                args['extra_headers'] = extra_keys['extra_headers']
 
             try:
                 fn_results = None
@@ -448,7 +450,9 @@ class Worker(object):
         self._put_results_from_response(object_info, headers)
 
     def handle_get_object(self, object_info):
+        extra_headers = object_info.get('get_headers')
         headers = self.ignoring_http_responses(
             (404, 503), client.get_object, object_info,
-            resp_chunk_size=object_info.get('block_size', DEFAULT_BLOCK_SIZE))
+            resp_chunk_size=object_info.get('block_size', DEFAULT_BLOCK_SIZE),
+            extra_headers=extra_headers)
         self._put_results_from_response(object_info, headers)


### PR DESCRIPTION
This option allows a user to specify additional headers to send to
each object GET request.

  "get_headers": {
      "range": "bytes=0-10,1000-1010"
  }