### PR TITLE
Include notices & attributions in each source code file

### DIFF
--- a/.copyright.config.json
+++ b/.copyright.config.json
@@ -1,0 +1,7 @@
+{
+    "author": "NVIDIA CORPORATION",
+    "license": "Apache-2.0",
+    "single": false,
+    "year": "2012-2021",
+    "pad": 0
+}

--- a/.copyright.templates.json
+++ b/.copyright.templates.json
@@ -1,0 +1,3 @@
+{
+    "Apache-2.0": "{short}\nCopyright (c) {year}, {author}.\nSPDX-License-Identifier: Apache-2.0"
+}

--- a/LICENSE-ordered_dict
+++ b/LICENSE-ordered_dict
@@ -1,0 +1,21 @@
+File: ssbench/ordered_dict.py
+
+Copyright 2009 Raymond Hettinger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/bin/ssbench-master
+++ b/bin/ssbench-master
@@ -1,18 +1,8 @@
 #!/usr/bin/env python
-# Copyright (c) 2012-2013 SwiftStack, Inc.
+
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import os
 import re

--- a/bin/ssbench-worker
+++ b/bin/ssbench-worker
@@ -1,18 +1,8 @@
 #!/usr/bin/env python
-# Copyright (c) 2012-2013 SwiftStack, Inc.
+
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import sys
 import argparse

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,7 @@
-#!/usr/bin/python
-# Copyright (c) 2013 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
+
 import os
 import sys
 from glob import glob

--- a/ssbench/__init__.py
+++ b/ssbench/__init__.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 _version = (0, 3, 9)
 version = '.'.join(map(str, _version))

--- a/ssbench/importer.py
+++ b/ssbench/importer.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2013-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 # Handle any/all wacky imports here
 

--- a/ssbench/master.py
+++ b/ssbench/master.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import gevent
 import gevent.pool

--- a/ssbench/ordered_dict.py
+++ b/ssbench/ordered_dict.py
@@ -1,7 +1,12 @@
 # {{{ http://code.activestate.com/recipes/576693/ (r9)
+
+#Copyright (c) 2009, Raymond Hettinger
+#SPDX-License-Identifier: MIT
+
 # Backport of OrderedDict() class that runs on Python 2.4, 2.5, 2.6, 2.7 and
 # pypy.
 # Passes Python2.7's test suite and incorporates all the latest updates.
+
 
 try:
     from thread import get_ident as _get_ident

--- a/ssbench/reporter.py
+++ b/ssbench/reporter.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import csv
 import math

--- a/ssbench/run_results.py
+++ b/ssbench/run_results.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import os
 import logging

--- a/ssbench/run_state.py
+++ b/ssbench/run_state.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 from collections import defaultdict, deque
 

--- a/ssbench/scenario.py
+++ b/ssbench/scenario.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import copy
 import json

--- a/ssbench/swift_client.py
+++ b/ssbench/swift_client.py
@@ -1,18 +1,7 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
-# Copyright (c) 2010-2013 OpenStack, LLC.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#Copyright (c) 2010-2012 OpenStack, LLC.
+#SPDX-License-Identifier: Apache-2.0
 
 # NOTE: hacked by SwiftStack for benchmarking
 

--- a/ssbench/tests/__init__.py
+++ b/ssbench/tests/__init__.py
@@ -1,0 +1,3 @@
+#
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0

--- a/ssbench/tests/test_master.py
+++ b/ssbench/tests/test_master.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import sys
 import textwrap

--- a/ssbench/tests/test_reporter.py
+++ b/ssbench/tests/test_reporter.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import csv
 from mock import MagicMock

--- a/ssbench/tests/test_run_results.py
+++ b/ssbench/tests/test_run_results.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import os
 import time

--- a/ssbench/tests/test_run_state.py
+++ b/ssbench/tests/test_run_state.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 from nose.tools import assert_equal, assert_set_equal
 from collections import deque

--- a/ssbench/tests/test_scenario.py
+++ b/ssbench/tests/test_scenario.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import json
 import time

--- a/ssbench/tests/test_util.py
+++ b/ssbench/tests/test_util.py
@@ -1,4 +1,6 @@
-# Copyright (c) 2016 SwiftStack, Inc.
+#
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import math
 import mock

--- a/ssbench/tests/test_worker.py
+++ b/ssbench/tests/test_worker.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import time
 import socket

--- a/ssbench/util.py
+++ b/ssbench/util.py
@@ -1,4 +1,6 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
+#
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
 
 import math
 import os

--- a/ssbench/worker.py
+++ b/ssbench/worker.py
@@ -1,18 +1,7 @@
-# Copyright (c) 2012-2015 SwiftStack, Inc.
-# Copyright (c) 2010-2012 OpenStack, LLC.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#Copyright (c) 2010-2012 OpenStack, LLC.
+#SPDX-License-Identifier: Apache-2.0
 #
 # Portions of this file copied from swift/common/bench.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,7 @@
+#
+#Copyright (c) 2012-2021, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
+
 [tox]
 envlist = py26,py27,pep8
 


### PR DESCRIPTION
[NSVISCS-1361]

Auto-added with this command-line (but the ordered-dict file was fixed by hand):
```
copyright -S -q -c .copyright.config.json -A -t .copyright.templates.json -e '*.md,*.patch,*.conf,AUTHORS,*.rst,*.scenario,ordered_dict.py' *
```